### PR TITLE
Correct link in "Help online" button so it points to a correct repository

### DIFF
--- a/nodes/siaendpoint-config.html
+++ b/nodes/siaendpoint-config.html
@@ -45,7 +45,7 @@
 
 <script type="text/html" data-template-name="siaendpoint-config">
     <div class="form-row">
-        <b>Server config</b>&nbsp&nbsp&nbsp&nbsp<span style="color:red"><i class="fa fa-question-circle"></i>&nbsp<a target="_blank" href="https://github.com/Supergiovane/node-red-contrib-hikvision-ultimate"><u>Help online</u></a></span>
+        <b>Server config</b>&nbsp&nbsp&nbsp&nbsp<span style="color:red"><i class="fa fa-question-circle"></i>&nbsp<a target="_blank" href="https://github.com/Supergiovane/node-red-contrib-sia-ultimate"><u>Help online</u></a></span>
         <br/>
         <br/>        
     </div>


### PR DESCRIPTION
Hi there,

in the node-red module, there is a "help online" link:

![Image](https://github.com/user-attachments/assets/22385e01-81c5-43cc-b9f8-bc368e4ba408)

However, it links to the wrong repository (node-red-contrib-hikvision-ultimate)

This commit changes it to the correct link. 