### PR TITLE
Fix crash if receiving malformed CRC format

### DIFF
--- a/nodes/siaendpoint-config.js
+++ b/nodes/siaendpoint-config.js
@@ -620,6 +620,10 @@ module.exports = (RED) => {
                 sia.cr = data[len]; // <cr>
                 // str = new Buffer((data.subarray(7, len)));
 
+                if (str == null) {
+                    RED.log.info("siaendpointConfig: Could not detect CRC format (neither hex nor binary)");
+                    return undefined;
+                }
                 sia.str = str.toString();
                 sia.calc_len = str.length;
                 sia.calc_crc = crc16str(str);


### PR DESCRIPTION
If the node receives a packet with a malformed CRC it would throw an uncaught exception that would crash Node Red.
Added check for invalid CRC format (unallocated CRC buffer) resulting in a NACK response instead of crashing 